### PR TITLE
fix(tiles): int overflow

### DIFF
--- a/ngx_http_mbtiles_module.c
+++ b/ngx_http_mbtiles_module.c
@@ -199,7 +199,7 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
     unsigned char *tile_content;
     unsigned int  tile_read_bytes;
     short         tile_zoom;
-    unsigned int  tile_row, tile_column, tms_tile_row;
+    unsigned long  tile_row, tile_column, tms_tile_row;
 
     ngx_http_mbtiles_loc_conf_t *mbtiles_config;
     mbtiles_config = ngx_http_get_module_loc_conf(r, ngx_http_mbtiles_module);
@@ -249,7 +249,7 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
     tile_zoom = strtol(ngx_str_t_to_char_ptr(mbtiles_zoom), NULL, 10);
     tile_column = strtol(ngx_str_t_to_char_ptr(mbtiles_column), NULL, 10);
     tile_row = strtol(ngx_str_t_to_char_ptr(mbtiles_row), NULL, 10);
-    tms_tile_row = (1u << tile_zoom) - tile_row - 1;
+    tms_tile_row = (1ul << tile_zoom) - tile_row - 1;
     if (SQLITE_OK != (sqlite3_ret = sqlite3_bind_int(sqlite_stmt, 1, tile_zoom)
             || SQLITE_OK != sqlite3_bind_int(sqlite_stmt, 2, tile_column)
             || SQLITE_OK != sqlite3_bind_int(sqlite_stmt, 3, tms_tile_row))) {
@@ -261,7 +261,7 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
 
     /* execute query */
     if (SQLITE_ROW != (sqlite3_ret = sqlite3_step(sqlite_stmt))) {
-	ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Could not find a tile (ret=%i) for zoom=%d, column=%d, row=%d (TMS row: %d)", sqlite3_ret, tile_zoom, tile_column, tile_row, tms_tile_row);
+	ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Could not find a tile (ret=%i) for zoom=%d, column=%%lu, row=%%lu (TMS row: %%lu)", sqlite3_ret, tile_zoom, tile_column, tile_row, tms_tile_row);
         sqlite3_finalize(sqlite_stmt);
         sqlite3_close(sqlite_handle);
         return NGX_HTTP_NO_CONTENT;

--- a/ngx_http_mbtiles_module.c
+++ b/ngx_http_mbtiles_module.c
@@ -249,7 +249,7 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
     tile_zoom = strtol(ngx_str_t_to_char_ptr(mbtiles_zoom), NULL, 10);
     tile_column = strtol(ngx_str_t_to_char_ptr(mbtiles_column), NULL, 10);
     tile_row = strtol(ngx_str_t_to_char_ptr(mbtiles_row), NULL, 10);
-    tms_tile_row = (1l << tile_zoom) - tile_row - 1;
+    tms_tile_row = (1u << tile_zoom) - tile_row - 1;
     if (SQLITE_OK != (sqlite3_ret = sqlite3_bind_int(sqlite_stmt, 1, tile_zoom)
             || SQLITE_OK != sqlite3_bind_int(sqlite_stmt, 2, tile_column)
             || SQLITE_OK != sqlite3_bind_int(sqlite_stmt, 3, tms_tile_row))) {

--- a/ngx_http_mbtiles_module.c
+++ b/ngx_http_mbtiles_module.c
@@ -261,7 +261,7 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
 
     /* execute query */
     if (SQLITE_ROW != (sqlite3_ret = sqlite3_step(sqlite_stmt))) {
-	ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "No tile found (ret=%i) for zoom=%d, column=%lu, row=%lu (TMS row: %lu)", sqlite3_ret, tile_zoom, tile_column, tile_row, tms_tile_row);
+	// ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "No tile found (ret=%i) for zoom=%d, column=%lu, row=%lu (TMS row: %lu)", sqlite3_ret, tile_zoom, tile_column, tile_row, tms_tile_row);
         sqlite3_finalize(sqlite_stmt);
         sqlite3_close(sqlite_handle);
         return NGX_HTTP_NO_CONTENT;

--- a/ngx_http_mbtiles_module.c
+++ b/ngx_http_mbtiles_module.c
@@ -261,7 +261,7 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
 
     /* execute query */
     if (SQLITE_ROW != (sqlite3_ret = sqlite3_step(sqlite_stmt))) {
-	ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Could not find a tile (ret=%i) for zoom=%d, column=%%lu, row=%%lu (TMS row: %%lu)", sqlite3_ret, tile_zoom, tile_column, tile_row, tms_tile_row);
+	ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "No tile found (ret=%i) for zoom=%d, column=%lu, row=%lu (TMS row: %lu)", sqlite3_ret, tile_zoom, tile_column, tile_row, tms_tile_row);
         sqlite3_finalize(sqlite_stmt);
         sqlite3_close(sqlite_handle);
         return NGX_HTTP_NO_CONTENT;

--- a/ngx_http_mbtiles_module.c
+++ b/ngx_http_mbtiles_module.c
@@ -260,7 +260,7 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
 
     /* execute query */
     if (SQLITE_ROW != (sqlite3_ret = sqlite3_step(sqlite_stmt))) {
-	// ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Could not find a tile (ret=%i) for zoom=%d, column=%d, row=%d (TMS row: %d)", sqlite3_ret, tile_zoom, tile_column, tile_row, tms_tile_row);
+	ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "Could not find a tile (ret=%i) for zoom=%d, column=%d, row=%d (TMS row: %d)", sqlite3_ret, tile_zoom, tile_column, tile_row, tms_tile_row);
         sqlite3_finalize(sqlite_stmt);
         sqlite3_close(sqlite_handle);
         return NGX_HTTP_NO_CONTENT;

--- a/ngx_http_mbtiles_module.c
+++ b/ngx_http_mbtiles_module.c
@@ -198,7 +198,8 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
     unsigned int  sqlite3_ret;
     unsigned char *tile_content;
     unsigned int  tile_read_bytes;
-    short         tile_zoom, tile_row, tile_column, tms_tile_row;
+    short         tile_zoom;
+    unsigned int  tile_row, tile_column, tms_tile_row;
 
     ngx_http_mbtiles_loc_conf_t *mbtiles_config;
     mbtiles_config = ngx_http_get_module_loc_conf(r, ngx_http_mbtiles_module);

--- a/ngx_http_mbtiles_module.c
+++ b/ngx_http_mbtiles_module.c
@@ -248,7 +248,7 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
     tile_zoom = strtol(ngx_str_t_to_char_ptr(mbtiles_zoom), NULL, 10);
     tile_column = strtol(ngx_str_t_to_char_ptr(mbtiles_column), NULL, 10);
     tile_row = strtol(ngx_str_t_to_char_ptr(mbtiles_row), NULL, 10);
-    tms_tile_row = (1 << tile_zoom) - tile_row - 1;
+    tms_tile_row = (1l << tile_zoom) - tile_row - 1;
     if (SQLITE_OK != (sqlite3_ret = sqlite3_bind_int(sqlite_stmt, 1, tile_zoom)
             || SQLITE_OK != sqlite3_bind_int(sqlite_stmt, 2, tile_column)
             || SQLITE_OK != sqlite3_bind_int(sqlite_stmt, 3, tms_tile_row))) {

--- a/ngx_http_mbtiles_module.c
+++ b/ngx_http_mbtiles_module.c
@@ -199,7 +199,7 @@ ngx_http_mbtiles_handler(ngx_http_request_t *r)
     unsigned char *tile_content;
     unsigned int  tile_read_bytes;
     short         tile_zoom;
-    unsigned long  tile_row, tile_column, tms_tile_row;
+    unsigned long tile_row, tile_column, tms_tile_row;
 
     ngx_http_mbtiles_loc_conf_t *mbtiles_config;
     mbtiles_config = ngx_http_get_module_loc_conf(r, ngx_http_mbtiles_module);


### PR DESCRIPTION
https://www.notion.so/FPD-parcel-data-disappears-at-specific-zoom-levels-464c7052c5344b3db8a7f7bba23f0d75

At zoom level 16 with regular integers we were getting an int overflow and (1 << 16) was computing to 0. This PR switches to unsigned longs when computing the transformed y tile.